### PR TITLE
feat: add ability to update themes after theme manager construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,57 +18,56 @@ npm install react-native-safe-area-context react-native-theme-mk
 
 #### `Constructor options`
 
-| Option                    | Description                                      |
-|---------------------------|--------------------------------------------------|
-| `dimensionsDesignedDevice`| Dimensions of the designed device (optional).    |
-| `autoScale`               | Enables auto-scaling (optional).                 |
+| Option                     | Description                                   |
+| -------------------------- | --------------------------------------------- |
+| `dimensionsDesignedDevice` | Dimensions of the designed device (optional). |
+| `autoScale`                | Enables auto-scaling (optional).              |
 
 #### `Methods and fields`
 
-| Method/Field              | Description                                      |
-|---------------------------|--------------------------------------------------|
-| `name`                    | The name of the current theme.                   |
-| `theme`                   | The current theme object.                        |
-| `context`                 | The React context for the current theme.         |
-| `set`                     | Sets the current theme by name.                  |
-| `get`                     | Gets a theme by name.                            |
-| `onChangeName`            | Registers a callback for theme name changes.     |
-| `removeAllListeners`      | Removes all registered listeners.                |
-| `createStyleSheet`        | Creates a style sheet using the provided styles creator. |
-| `useTheme`                | Hook to use the current theme.                   |
-| `useDevice`               | Hook to use the device information.              |
-| `useScale`                | Hook to use the scale factor.                    |
-| `device`                  | The device information.                          |
-| `dimensionsDesignedDevice`| The dimensions of the designed device.           |
-
+| Method/Field               | Description                                              |
+| -------------------------- | -------------------------------------------------------- |
+| `name`                     | The name of the current theme.                           |
+| `theme`                    | The current theme object.                                |
+| `context`                  | The React context for the current theme.                 |
+| `set`                      | Sets the current theme by name.                          |
+| `get`                      | Gets a theme by name.                                    |
+| `update`                   | Performs a deep merge to update/extend themes.           |
+| `onChangeName`             | Registers a callback for theme name changes.             |
+| `removeAllListeners`       | Removes all registered listeners.                        |
+| `createStyleSheet`         | Creates a style sheet using the provided styles creator. |
+| `useTheme`                 | Hook to use the current theme.                           |
+| `useDevice`                | Hook to use the device information.                      |
+| `useScale`                 | Hook to use the scale factor.                            |
+| `device`                   | The device information.                                  |
+| `dimensionsDesignedDevice` | The dimensions of the designed device.                   |
 
 #### createStyleSheet
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `params`  | object | An object containing the following properties: |
-| `params.theme` | `C[keyof C]` | The current theme object. |
-| `params.device` | `IDevice` | The device information. |
-| `params.scale` | `number` | The scale factor. |
+| Parameter       | Type         | Description                                    |
+| --------------- | ------------ | ---------------------------------------------- |
+| `params`        | object       | An object containing the following properties: |
+| `params.theme`  | `C[keyof C]` | The current theme object.                      |
+| `params.device` | `IDevice`    | The device information.                        |
+| `params.scale`  | `number`     | The scale factor.                              |
 
 #### Device
 
-| Property                  | Description                                      |
-|---------------------------|--------------------------------------------------|
-| `isAndroid`               | Indicates if the device is running Android.      |
-| `isIOS`                   | Indicates if the device is running iOS.          |
-| `isTablet`                | Indicates if the device is a tablet.             |
-| `isIphoneX`               | Indicates if the device is an iPhone X.          |
-| `window`                  | Dimensions of the device's window.               |
-| `screen`                  | Dimensions of the device's screen.               |
-| `orientation`             | Current orientation of the device.               |
-| `isLandscape`             | Indicates if the device is in landscape mode.    |
-| `isPortrait`              | Indicates if the device is in portrait mode.     |
-| `inset`                   | Insets of the device's screen.                   |
-| `isSmallScreen`           | Indicates if the device has a small screen.      |
-| `isShortScreen`           | Indicates if the device has a short screen.      |
-| `screenAspectRatio`       | Aspect ratio of the device's screen.             |
-
+| Property            | Description                                   |
+| ------------------- | --------------------------------------------- |
+| `isAndroid`         | Indicates if the device is running Android.   |
+| `isIOS`             | Indicates if the device is running iOS.       |
+| `isTablet`          | Indicates if the device is a tablet.          |
+| `isIphoneX`         | Indicates if the device is an iPhone X.       |
+| `window`            | Dimensions of the device's window.            |
+| `screen`            | Dimensions of the device's screen.            |
+| `orientation`       | Current orientation of the device.            |
+| `isLandscape`       | Indicates if the device is in landscape mode. |
+| `isPortrait`        | Indicates if the device is in portrait mode.  |
+| `inset`             | Insets of the device's screen.                |
+| `isSmallScreen`     | Indicates if the device has a small screen.   |
+| `isShortScreen`     | Indicates if the device has a short screen.   |
+| `screenAspectRatio` | Aspect ratio of the device's screen.          |
 
 ### `Example`
 
@@ -129,7 +128,6 @@ export const useStyles = ThemeManager.createStyleSheet(({ theme }) => ({
         backgroundColor: theme.colors.accent,
     },
 }));
-
 ```
 
 ```js
@@ -153,6 +151,23 @@ export const HomeScreen = () => {
         </View>
     );
 };
+```
+
+```js
+import { ThemeManager } from './styles';
+
+ThemeManager.update({
+    light: {
+        colors: {
+            newColor: '#123456',
+        },
+    },
+    dark: {
+        colors: {
+            newColor: '#abcdef',
+        },
+    },
+});
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@react-native/eslint-config": "^0.73.1",
     "@release-it/conventional-changelog": "^5.0.0",
     "@types/jest": "^29.5.5",
+    "@types/lodash": "^4.17.20",
     "@types/react": "^18.2.44",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
@@ -87,7 +88,8 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "events": "^3.3.0"
+    "events": "^3.3.0",
+    "lodash.merge": "^4.6.2"
   },
   "resolutions": {
     "@types/react": "^18.2.44"

--- a/src/theme-manager.tsx
+++ b/src/theme-manager.tsx
@@ -13,12 +13,14 @@ import {
     type IStyleCreator,
     type INamedStyles,
     type IScale,
+    type DeepPartial,
 } from './types';
 import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Device } from './device';
 import { dimensionsDesignedDeviceConfig } from './config';
 import { applyScale } from './scale';
 import { hexToRgba } from './utils';
+import merge from 'lodash/merge';
 
 enum Events {
     ChangeTheme = 'ChangeTheme',
@@ -58,6 +60,10 @@ export class ThemeManager<C extends Record<string, object>> implements IThemeMan
 
     get(name: keyof C) {
         return this.themes[name];
+    }
+
+    update(extendedThemes: DeepPartial<C>) {
+        this.themes = merge({}, this.themes, extendedThemes);
     }
 
     onChangeName(cb: OnChangeCallBack<keyof C>): () => void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,13 @@ export interface IThemeManager<C extends Record<string, object>> {
     get(name: keyof C): C[keyof C];
 
     /**
+     * Updates one or more themes.
+     *
+     * @param extendedThemes - An object consisting of partial or full themes.
+     */
+    update(extendedThemes: DeepPartial<C>): void;
+
+    /**
      * Registers a callback to be called when the theme name changes.
      *
      * @param cb - The callback function.
@@ -242,3 +249,7 @@ export interface IOptions {
     dimensionsDesignedDevice?: IDimensionDesignedDevice;
     autoScale?: boolean;
 }
+
+export type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4281,6 +4281,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/lodash@npm:^4.17.20":
+  version: 4.17.20
+  resolution: "@types/lodash@npm:4.17.20"
+  checksum: dc7bb4653514dd91117a4c4cec2c37e2b5a163d7643445e4757d76a360fabe064422ec7a42dde7450c5e7e0e7e678d5e6eae6d2a919abcddf581d81e63e63839
+  languageName: node
+  linkType: hard
+
 "@types/minimist@npm:^1.2.0, @types/minimist@npm:^1.2.2":
   version: 1.2.5
   resolution: "@types/minimist@npm:1.2.5"
@@ -13224,6 +13231,7 @@ __metadata:
     "@react-native/eslint-config": ^0.73.1
     "@release-it/conventional-changelog": ^5.0.0
     "@types/jest": ^29.5.5
+    "@types/lodash": ^4.17.20
     "@types/react": ^18.2.44
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
@@ -13234,6 +13242,7 @@ __metadata:
     eslint-plugin-prettier: ^5.0.1
     events: ^3.3.0
     jest: ^29.7.0
+    lodash.merge: ^4.6.2
     prettier: ^3.0.3
     react: 18.2.0
     react-native: 0.74.5


### PR DESCRIPTION
Adds an update() function to ThemeManager allowing the themes to be updated after ThemeManager construction.

Use case -

Build a React Native component library using this library. The consumer of the library wants to:

- override some predefined theme elements (e.g. change primary color)
- extend the theme by adding new elements (e.g. add newColor)

In this example the component library wraps and exports this libraries capabilities.

The functional change is very simple. To showcase an example using this use case is more difficult. I have used your example to successfully implement this use case. You can see npm package (wip) react-native-hello. I reworked all the types so module augmentation for typescript autocomplete works.
